### PR TITLE
[Cleanup] use C code that is also compatible with C++

### DIFF
--- a/src/raylib_game.c
+++ b/src/raylib_game.c
@@ -23,7 +23,7 @@
 // Shared Variables Definition (global)
 // NOTE: Those variables are shared between modules through screens.h
 //----------------------------------------------------------------------------------
-GameScreen currentScreen = 0;
+GameScreen currentScreen = LOGO;
 Font font = { 0 };
 Music music = { 0 };
 Sound fxCoin = { 0 };
@@ -39,7 +39,7 @@ static float transAlpha = 0.0f;
 static bool onTransition = false;
 static bool transFadeOut = false;
 static int transFromScreen = -1;
-static int transToScreen = -1;
+static GameScreen transToScreen = UNKNOWN;
 
 //----------------------------------------------------------------------------------
 // Local Functions Declaration
@@ -117,7 +117,7 @@ int main(void)
 // Module specific Functions Definition
 //----------------------------------------------------------------------------------
 // Change to next screen, no transition
-static void ChangeToScreen(int screen)
+static void ChangeToScreen(GameScreen screen)
 {
     // Unload current screen
     switch (currentScreen)
@@ -143,7 +143,7 @@ static void ChangeToScreen(int screen)
 }
 
 // Request transition to next screen
-static void TransitionToScreen(int screen)
+static void TransitionToScreen(GameScreen screen)
 {
     onTransition = true;
     transFadeOut = false;
@@ -202,7 +202,7 @@ static void UpdateTransition(void)
             transFadeOut = false;
             onTransition = false;
             transFromScreen = -1;
-            transToScreen = -1;
+            transToScreen = UNKNOWN;
         }
     }
 }

--- a/src/screen_ending.c
+++ b/src/screen_ending.c
@@ -62,7 +62,9 @@ void DrawEndingScreen(void)
 {
     // TODO: Draw ENDING screen here!
     DrawRectangle(0, 0, GetScreenWidth(), GetScreenHeight(), BLUE);
-    DrawTextEx(font, "ENDING SCREEN", (Vector2){ 20, 10 }, font.baseSize*3, 4, DARKBLUE);
+
+    Vector2 pos = { 20, 10 };
+    DrawTextEx(font, "ENDING SCREEN", pos, font.baseSize*3.0f, 4, DARKBLUE);
     DrawText("PRESS ENTER or TAP to RETURN to TITLE SCREEN", 120, 220, 20, DARKBLUE);
 }
 

--- a/src/screen_gameplay.c
+++ b/src/screen_gameplay.c
@@ -62,7 +62,8 @@ void DrawGameplayScreen(void)
 {
     // TODO: Draw GAMEPLAY screen here!
     DrawRectangle(0, 0, GetScreenWidth(), GetScreenHeight(), PURPLE);
-    DrawTextEx(font, "GAMEPLAY SCREEN", (Vector2){ 20, 10 }, font.baseSize*3, 4, MAROON);
+    Vector2 pos = { 20, 10 };
+    DrawTextEx(font, "GAMEPLAY SCREEN", pos, font.baseSize*3.0f, 4, MAROON);
     DrawText("PRESS ENTER or TAP to JUMP to ENDING SCREEN", 130, 220, 20, MAROON);
 }
 

--- a/src/screen_title.c
+++ b/src/screen_title.c
@@ -63,7 +63,8 @@ void DrawTitleScreen(void)
 {
     // TODO: Draw TITLE screen here!
     DrawRectangle(0, 0, GetScreenWidth(), GetScreenHeight(), GREEN);
-    DrawTextEx(font, "TITLE SCREEN", (Vector2){ 20, 10 }, font.baseSize*3, 4, DARKGREEN);
+    Vector2 pos = { 20, 10 };
+    DrawTextEx(font, "TITLE SCREEN", pos, font.baseSize*3.0f, 4, DARKGREEN);
     DrawText("PRESS ENTER or TAP to JUMP to GAMEPLAY SCREEN", 120, 220, 20, DARKGREEN);
 }
 

--- a/src/screens.h
+++ b/src/screens.h
@@ -29,7 +29,7 @@
 //----------------------------------------------------------------------------------
 // Types and Structures Definition
 //----------------------------------------------------------------------------------
-typedef enum GameScreen { LOGO = 0, TITLE, OPTIONS, GAMEPLAY, ENDING } GameScreen;
+typedef enum GameScreen { UNKNOWN = -1, LOGO = 0, TITLE, OPTIONS, GAMEPLAY, ENDING } GameScreen;
 
 //----------------------------------------------------------------------------------
 // Global Variables Declaration (shared by several modules)


### PR DESCRIPTION
While the template is valid C code, it does not work well when converted to C++. Some users would like to use the template as the starting point for C++ code.

This PR makes a few small changes to the C code to make it also compatible with C++.

1) use the scene enums everywhere, not a mix of enums and numbers (also makes the code read better)
2) don't pass the address of unnamed temp variables into functions, allocate an actual structure.

These changes allow the c files to be simply renamed C++ and compile without issues.