### PR TITLE
update python path, add emscripten header path, add run target, clean more files

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -21,7 +21,7 @@
 #
 #**************************************************************************************************
 
-.PHONY: all clean
+.PHONY: all clean run
 
 # Define required environment variables
 #------------------------------------------------------------------------------------------------
@@ -161,7 +161,7 @@ ifeq ($(OS),Windows_NT)
         EMSDK_PATH         ?= C:/emsdk
         EMSCRIPTEN_PATH    ?= $(EMSDK_PATH)/upstream/emscripten
         CLANG_PATH          = $(EMSDK_PATH)/upstream/bin
-        PYTHON_PATH         = $(EMSDK_PATH)/python/3.9.2-1_64bit
+        PYTHON_PATH         = $(EMSDK_PATH)/python/3.9.2-nuget_64bit
         NODE_PATH           = $(EMSDK_PATH)/node/14.15.5_64bit/bin
         export PATH         = $(EMSDK_PATH);$(EMSCRIPTEN_PATH);$(CLANG_PATH);$(NODE_PATH);$(PYTHON_PATH):$$(PATH)
     endif
@@ -259,7 +259,6 @@ endif
 # NOTE: Some external/extras libraries could be required (stb, physac, easings...)
 #------------------------------------------------------------------------------------------------
 INCLUDE_PATHS = -I. -I$(RAYLIB_PATH)/src -I$(RAYLIB_PATH)/src/external -I$(RAYLIB_PATH)/src/extras
-
 # Define additional directories containing required header files
 ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     ifeq ($(PLATFORM_OS),BSD)
@@ -276,6 +275,9 @@ ifeq ($(PLATFORM),PLATFORM_RPI)
 endif
 ifeq ($(PLATFORM),PLATFORM_DRM)
     INCLUDE_PATHS += -I/usr/include/libdrm
+endif
+ifeq ($(PLATFORM),PLATFORM_WEB)
+    INCLUDE_PATHS += -I$(EMSCRIPTEN_PATH)/cache/sysroot/include
 endif
 
 # Define library paths containing required libs: LDFLAGS
@@ -439,6 +441,21 @@ $(PROJECT_NAME): $(OBJS)
 %.o: %.c
 	$(CC) -c $< -o $@ $(CFLAGS) $(INCLUDE_PATHS) -D$(PLATFORM)
 
+run:
+	$(MAKE) $(MAKEFILE_PARAMS)
+
+ifeq ($(PLATFORM),PLATFORM_DESKTOP)
+    ifeq ($(PLATFORM_OS),WINDOWS)
+		$(PROJECT_NAME)
+    endif
+    ifeq ($(PLATFORM_OS),LINUX)
+		./$(PROJECT_NAME)
+    endif
+    ifeq ($(PLATFORM_OS),OSX)
+		./$(PROJECT_NAME)
+    endif
+endif
+
 .PHONY: clean_shell_cmd clean_shell_sh
 
 # Clean everything
@@ -468,4 +485,4 @@ endif
 # Set specific target variable
 clean_shell_cmd: SHELL=cmd
 clean_shell_cmd:
-	del *.o *.exe /s
+	del *.o *.exe $(PROJECT_NAME).data $(PROJECT_NAME).html $(PROJECT_NAME).js $(PROJECT_NAME).wasm /s

--- a/src/Makefile
+++ b/src/Makefile
@@ -259,6 +259,7 @@ endif
 # NOTE: Some external/extras libraries could be required (stb, physac, easings...)
 #------------------------------------------------------------------------------------------------
 INCLUDE_PATHS = -I. -I$(RAYLIB_PATH)/src -I$(RAYLIB_PATH)/src/external -I$(RAYLIB_PATH)/src/extras
+
 # Define additional directories containing required header files
 ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     ifeq ($(PLATFORM_OS),BSD)


### PR DESCRIPTION
Tested on Windows: w64devkit and web target, and Linux.

1. emsdk python path was updated some time ago:
https://github.com/emscripten-core/emsdk/pull/1010/files
https://github.com/emscripten-core/emsdk/pull/1024

2. included emscripten.h so clangd can find it, behind web platform check

3. added web target output files to the clean target

4. added a run target to allow creating a "make run -s" shortcut in editors that you never have to change regardless of project name

Side note: I noticed that https://github.com/raysan5/raylib-game-template/blob/ee00a999c8fae4550740d757be715d4631777d86/src/Makefile#L138-L145 breaks builds on linux if you only `make` raylib instead of `sudo make install`. If you remove those lines it works again like on windows. I found the following notes in the first commit so I don't want to break some1s workflow though (I'm not sure what it is for):

```
# RAYLIB_PATH adjustment for different platforms.
# If using GNU make, we can get the full path to the top of the tree. Windows? BSD?
# Required for ldconfig or other tools that do not perform path expansion.
ifeq ($(PLATFORM),PLATFORM_DESKTOP)
    ifeq ($(PLATFORM_OS),LINUX)
        RAYLIB_PREFIX ?= ..
        RAYLIB_PATH    = $(realpath $(RAYLIB_PREFIX))
    endif
endif
```