### PR TITLE
kill process if needed to restart

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -192,7 +192,7 @@ MAKE ?= make
 
 ifeq ($(PLATFORM),PLATFORM_DESKTOP)
     ifeq ($(PLATFORM_OS),WINDOWS)
-        MAKE = mingw32-make
+        MAKE = taskkill /im $(PROJECT_NAME).exe > nul 2>&1 & mingw32-make
     endif
 endif
 ifeq ($(PLATFORM),PLATFORM_ANDROID)


### PR DESCRIPTION
This allows make to recompile even if the process is still running, so you don't have to exit out first.

Just windows for now.