### PR TITLE
Add "keyboard" to android:configChanges

### DIFF
--- a/src/Makefile.Android
+++ b/src/Makefile.Android
@@ -231,7 +231,7 @@ generate_android_manifest:
 	@echo     ^<application android:allowBackup="false" android:label="@string/app_name" android:icon="@drawable/icon" ^> >> $(PROJECT_BUILD_PATH)/AndroidManifest.xml
 	@echo         ^<activity android:name="com.$(APP_COMPANY_NAME).$(APP_PRODUCT_NAME).NativeLoader" >> $(PROJECT_BUILD_PATH)/AndroidManifest.xml
 	@echo             android:theme="@android:style/Theme.NoTitleBar.Fullscreen" >> $(PROJECT_BUILD_PATH)/AndroidManifest.xml
-	@echo             android:configChanges="orientation|keyboardHidden|screenSize" >> $(PROJECT_BUILD_PATH)/AndroidManifest.xml
+	@echo             android:configChanges="orientation|keyboard|keyboardHidden|screenSize" >> $(PROJECT_BUILD_PATH)/AndroidManifest.xml
 	@echo             android:screenOrientation="$(APP_SCREEN_ORIENTATION)" android:launchMode="singleTask" >> $(PROJECT_BUILD_PATH)/AndroidManifest.xml
 	@echo             android:clearTaskOnLaunch="true" >> $(PROJECT_BUILD_PATH)/AndroidManifest.xml
 	@echo             android:exported="true"^> >> $(PROJECT_BUILD_PATH)/AndroidManifest.xml


### PR DESCRIPTION
This prevents the game from freezing on Android if a physical keyboard is connected or removed while the game is running, as mentioned in https://github.com/raysan5/raylib/pull/3733.