### PR TITLE
Typo, other→others

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,4 +1,4 @@
-## C Coding Style Conventions
+ ## C Coding Style Conventions
 
 Code element | Convention | Example
 --- | :---: | ---
@@ -86,4 +86,4 @@ resources/characters/enemy_slime.png
 resources/common/font_arial.ttf
 resources/common/gui.png
 ```
-_NOTE: Some resources require to be loaded all at once while other require to be loaded only at initialization (gui, font)._
+_NOTE: Some resources require to be loaded all at once while others require to be loaded only at initialization (gui, font)._

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,4 +1,4 @@
- ## C Coding Style Conventions
+## C Coding Style Conventions
 
 Code element | Convention | Example
 --- | :---: | ---


### PR DESCRIPTION
Simple typo fix. Changed "other" to "others" in the sentence "Some resources require to be loaded all at once while others require to be loaded only at initialization"