### PR TITLE
Updated CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.30)
+cmake_minimum_required(VERSION 3.24...3.30)
 project(raylib-game-template)
 
 include(FetchContent)


### PR DESCRIPTION
The function FIND_PACKAGE_ARGS requires version 3.24, so I updated the minimum cmake version to reflect that.