### PR TITLE
Fix path for loading resources

### DIFF
--- a/src/raylib_game.c
+++ b/src/raylib_game.c
@@ -64,9 +64,9 @@ int main(void)
     InitAudioDevice();      // Initialize audio device
 
     // Load global data (assets that must be available in all screens, i.e. font)
-    font = LoadFont("resources/mecha.png");
-    //music = LoadMusicStream("resources/ambient.ogg"); // TODO: Load music
-    fxCoin = LoadSound("resources/coin.wav");
+    font = LoadFont("src/resources/mecha.png");
+    //music = LoadMusicStream("src/resources/ambient.ogg"); // TODO: Load music
+    fxCoin = LoadSound("src/resources/coin.wav");
 
     SetMusicVolume(music, 1.0f);
     PlayMusicStream(music);


### PR DESCRIPTION
Today I created a new copy of the template in order to start a new project. So when I started to set up the system and check the template repo compiled properly, I noticed it didn't load resources correctly. The output from the tracelog is the following:
```
WARNING: FILEIO: [resources/mecha.png] Failed to open file
WARNING: FONT: [resources/mecha.png] Failed to load font texture -> Using default font
WARNING: FILEIO: [resources/coin.wav] Failed to open file
INFO: TIMER: Target time per frame: 16.667 milliseconds
INFO: STREAM: Unloaded audio stream data from RAM
INFO: AUDIO: Device closed successfully
INFO: TEXTURE: [ID 2] Unloaded texture data from VRAM (GPU)
INFO: SHADER: [ID 3] Default shader unloaded successfully
INFO: TEXTURE: [ID 1] Default texture unloaded successfully
```

I do not know the details of how it loads and where it looks for the files, I just did some tests and noticed that adding "src/" before the path set in the paths of the loading functions in **raylib_game.c**, solved the issue. It also works for the music, once it is not commented (line 68 of raylib_game.c).

This was only tested in a linux-based system running Pop!_OS (Ubuntu based, although some system libraries may differ), so I cannot say for sure this solves the issue for everything. I guess it does, as it is pretty straightforward thing, but maybe there is something I am missing. If that is the case, please let me know so I can look into it or assist to whomever may be in charge of this.