### PR TITLE
xcopy resources to project dir, otherwise the local debugger build ca…

### DIFF
--- a/projects/VS2022/raylib_game/raylib_game.vcxproj
+++ b/projects/VS2022/raylib_game/raylib_game.vcxproj
@@ -207,7 +207,7 @@
       <AdditionalDependencies>raylib.lib;opengl32.lib;kernel32.lib;user32.lib;gdi32.lib;winmm.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy /i /f /y $(ProjectDir)..\..\..\src\resources $(ProjectDir)resources\</Command>
+      <Command>xcopy /i /e /f /y $(ProjectDir)..\..\..\src\resources $(ProjectDir)resources\</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug.DLL|Win32'">

--- a/projects/VS2022/raylib_game/raylib_game.vcxproj
+++ b/projects/VS2022/raylib_game/raylib_game.vcxproj
@@ -206,6 +206,9 @@
       <AdditionalLibraryDirectories>$(SolutionDir)\build\raylib\bin\$(Platform)\$(Configuration)\</AdditionalLibraryDirectories>
       <AdditionalDependencies>raylib.lib;opengl32.lib;kernel32.lib;user32.lib;gdi32.lib;winmm.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
+    <PostBuildEvent>
+      <Command>xcopy /i /f /y $(ProjectDir)..\..\..\src\resources $(ProjectDir)resources\</Command>
+    </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug.DLL|Win32'">
     <ClCompile>


### PR DESCRIPTION
…n't find them

In my case I tried to set the working directory of the local windows debugger build to $(OutDir) but this is saved in the .user properties, so this is a good compromise to make the app work out of the box.

The problem is that it was failing to load the resources, because they live in /src, and are not copied to the project directory