### PR TITLE
Fix environment variable name when building raylib in CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,7 +8,7 @@ on:
       - '.github/workflows/linux.yml'
   release:
     types: [published]
-    
+
 permissions:
   contents: read
 
@@ -17,45 +17,45 @@ jobs:
     permissions:
       contents: write       # for actions/upload-release-asset to upload release asset
     runs-on: ubuntu-latest
-    
+
     env:
       PROJECT_NAME: ${{ github.event.repository.name }}
       PROJECT_BUILD_PATH: ${{ github.event.repository.name }}/src
       PROJECT_RELEASE_PATH: ${{ github.event.repository.name }}_dev_linux_x64
       PROJECT_CUSTOM_FLAGS: ""
       PROJECT_RESOURCES_PATH: src/resources
-    
+
     steps:
     - name: Checkout this repo
       uses: actions/checkout@master
       with:
         path: ${{ env.PROJECT_NAME }}
-      
+
     - name: Checkout raylib repo
       uses: actions/checkout@v4
       with:
         repository: raysan5/raylib
         path: raylib
-        
+
     - name: Setup Release Paths
       run: |
         echo "PROJECT_RELEASE_PATH=${{ env.PROJECT_NAME }}_v${{ github.event.release.tag_name }}_linux_x64" >> $GITHUB_ENV
       shell: bash
       if: github.event_name == 'release' && github.event.action == 'published'
-    
+
     - name: Setup Environment
-      run: | 
+      run: |
         sudo apt-get update -qq
         sudo apt-get install -y --no-install-recommends libglfw3 libglfw3-dev libx11-dev libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev libxext-dev libxfixes-dev libwayland-dev libxkbcommon-dev
         mkdir ${{ env.PROJECT_RELEASE_PATH }}
         ls
       shell: bash
-        
+
     - name: Build raylib Library
       run: |
         cd raylib/src
         gcc --version
-        make PLATFORM=PLATFORM_DESKTOP BUILD_MODE=RELEASE RAYLIB_LIBTYPE=STATIC RAYLIB_PROJECT_RELEASE_PATH=. -B
+        make PLATFORM=PLATFORM_DESKTOP BUILD_MODE=RELEASE RAYLIB_LIBTYPE=STATIC RAYLIB_RELEASE_PATH=. -B
 
     - name: Build Product
       run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,7 +8,7 @@ on:
       - '.github/workflows/macos.yml'
   release:
     types: [published]
-    
+
 permissions:
   contents: read
 
@@ -17,34 +17,34 @@ jobs:
     permissions:
       contents: write       # for actions/upload-release-asset to upload release asset
     runs-on: macos-latest
-    
+
     env:
       PROJECT_NAME: ${{ github.event.repository.name }}
       PROJECT_BUILD_PATH: ${{ github.event.repository.name }}/src
       PROJECT_RELEASE_PATH: ${{ github.event.repository.name }}_dev_macos
       PROJECT_CUSTOM_FLAGS: ""
       PROJECT_RESOURCES_PATH: resources
-    
+
     steps:
     - name: Checkout this repo
       uses: actions/checkout@master
       with:
         path: ${{ env.PROJECT_NAME }}
-      
+
     - name: Checkout raylib repo
       uses: actions/checkout@v4
       with:
         repository: raysan5/raylib
         path: raylib
-        
+
     - name: Setup Release Paths
       run: |
         echo "PROJECT_RELEASE_PATH=${{ env.PROJECT_NAME }}_v${{ github.event.release.tag_name }}_macos" >> $GITHUB_ENV
       shell: bash
       if: github.event_name == 'release' && github.event.action == 'published'
-      
+
     - name: Setup Environment
-      run: | 
+      run: |
         mkdir ${{ env.PROJECT_RELEASE_PATH }}
         cd ${{ env.PROJECT_RELEASE_PATH }}
         mkdir ${{ env.PROJECT_NAME }}.app
@@ -56,29 +56,29 @@ jobs:
         cd ../../..
         ls
       shell: bash
-             
+
     # Generating static library, note that i386 architecture is deprecated
     # Defining GL_SILENCE_DEPRECATION because OpenGL is deprecated on macOS
     - name: Build raylib Library
       run: |
         cd raylib/src
         clang --version
-        
+
         # Extract version numbers from Makefile
         brew install grep
         RAYLIB_API_VERSION=`ggrep -Po 'RAYLIB_API_VERSION\s*=\s\K(.*)' Makefile`
         RAYLIB_VERSION=`ggrep -Po 'RAYLIB_VERSION\s*=\s\K(.*)' Makefile`
-        
+
         # Build raylib x86_64 static
         make PLATFORM=PLATFORM_DESKTOP RAYLIB_LIBTYPE=STATIC CUSTOM_CFLAGS="-target x86_64-apple-macos10.12 -DGL_SILENCE_DEPRECATION"
         mv -v -f libraylib.a libraylib_x86_64.a
         make clean
-        
+
         # Build raylib arm64 static
         make PLATFORM=PLATFORM_DESKTOP RAYLIB_LIBTYPE=STATIC CUSTOM_CFLAGS="-target arm64-apple-macos11 -DGL_SILENCE_DEPRECATION" -B
         mv -v -f libraylib.a libraylib_arm64.a
         make clean
-        
+
         # Join x86_64 and arm64 static
         lipo -create -output libraylib.a libraylib_x86_64.a libraylib_arm64.a
         lipo libraylib.a -detailed_info
@@ -87,19 +87,19 @@ jobs:
     - name: Build Product
       run: |
         cd ${{ env.PROJECT_NAME }}/src
-        
+
         # Build project x86_64 binary
         # TODO: Link with x86_64 raylib library: libraylib_x86_64.a
         make PLATFORM=PLATFORM_DESKTOP BUILD_MODE=RELEASE PROJECT_CUSTOM_FLAGS=${{ env.PROJECT_CUSTOM_FLAGS }} PROJECT_BUILD_PATH=. RAYLIB_SRC_PATH=../../raylib/src PROJECT_CUSTOM_FLAGS="-target x86_64-apple-macos10.12"
         mv -v -f ${{ env.PROJECT_NAME }} ${{ env.PROJECT_NAME }}_x86_64
         make clean
-        
+
         # Build project arm64 binary
         # TODO: Link with arm64 raylib library: libraylib_arm.a
         make PLATFORM=PLATFORM_DESKTOP BUILD_MODE=RELEASE PROJECT_CUSTOM_FLAGS=${{ env.PROJECT_CUSTOM_FLAGS }} PROJECT_BUILD_PATH=. RAYLIB_SRC_PATH=../../raylib/src PROJECT_CUSTOM_FLAGS="-target arm64-apple-macos11"
         mv -v -f ${{ env.PROJECT_NAME }} ${{ env.PROJECT_NAME }}_arm64
         make clean
-        
+
         # Join x86_64 and arm64 binaries
         lipo -create -output ${{ env.PROJECT_NAME }} ${{ env.PROJECT_NAME }}_x86_64 ${{ env.PROJECT_NAME }}_arm64
         lipo ${{ env.PROJECT_NAME }} -detailed_info

--- a/.github/workflows/webassembly.yml
+++ b/.github/workflows/webassembly.yml
@@ -8,7 +8,7 @@ on:
       - '.github/workflows/webassembly.yml'
   release:
     types: [published]
-    
+
 permissions:
   contents: read
 
@@ -17,52 +17,52 @@ jobs:
     permissions:
       contents: write       # for actions/upload-release-asset to upload release asset
     runs-on: windows-latest
-    
+
     env:
       PROJECT_NAME: ${{ github.event.repository.name }}
       PROJECT_BUILD_PATH: ${{ github.event.repository.name }}\\src
       PROJECT_RELEASE_PATH: ${{ github.event.repository.name }}_dev_wasm
-      
+
     steps:
     - name: Checkout this repo
       uses: actions/checkout@master
       with:
         path: ${{ env.PROJECT_NAME }}
-      
+
     - name: Checkout raylib repo
       uses: actions/checkout@v4
       with:
         repository: raysan5/raylib
         path: raylib
-  
+
     - name: Setup emsdk
       uses: mymindstorm/setup-emsdk@v14
       with:
         version: 3.1.64
         actions-cache-folder: 'emsdk-cache'
-        
+
     - name: Setup Release Paths
       run: |
         echo "PROJECT_RELEASE_PATH=${{ env.PROJECT_NAME }}_v${{ github.event.release.tag_name }}_wasm" >> $GITHUB_ENV
       shell: bash
       if: github.event_name == 'release' && github.event.action == 'published'
-    
+
     - name: Setup Environment
-      run: | 
+      run: |
         mkdir ${{ env.PROJECT_RELEASE_PATH }}
         dir
-   
+
     - name: Build raylib Library
       run: |
         cd raylib/src
         emcc -v
-        make PLATFORM=PLATFORM_WEB RAYLIB_BUILD_MODE=RELEASE RAYLIB_LIBTYPE=STATIC EMSDK_PATH="D:/a/${{ env.PROJECT_NAME }}/${{ env.PROJECT_NAME }}/emsdk-cache/emsdk-main" RAYLIB_PROJECT_RELEASE_PATH=. -B
+        make PLATFORM=PLATFORM_WEB RAYLIB_BUILD_MODE=RELEASE RAYLIB_LIBTYPE=STATIC EMSDK_PATH="D:/a/${{ env.PROJECT_NAME }}/${{ env.PROJECT_NAME }}/emsdk-cache/emsdk-main" RAYLIB_RELEASE_PATH=. -B
 
     - name: Build Product
       run: |
         cd ${{ env.PROJECT_NAME }}/src
         make PLATFORM=PLATFORM_WEB BUILD_MODE=RELEASE EMSDK_PATH="D:/a/${{ env.PROJECT_NAME }}/${{ env.PROJECT_NAME }}/emsdk-cache/emsdk-main" PROJECT_BUILD_PATH=. RAYLIB_SRC_PATH=../../raylib/src -B
-  
+
     - name: Generate Artifacts
       run: |
         dir ${{ env.PROJECT_BUILD_PATH }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,7 +8,7 @@ on:
       - '.github/workflows/windows.yml'
   release:
     types: [published]
-    
+
 permissions:
   contents: read
 
@@ -29,13 +29,13 @@ jobs:
       uses: actions/checkout@master
       with:
         path: ${{ env.PROJECT_NAME }}
-      
+
     - name: Checkout raylib repo
       uses: actions/checkout@v4
       with:
         repository: raysan5/raylib
         path: raylib
-        
+
     # NOTE: Visual Studio project build configuration already defines all required directories where project is generated:
     # $(SolutionDir)\build\$(ProjectName)\bin\$(Platform)\$(Configuration)\
     - name: Setup Release Paths
@@ -45,7 +45,7 @@ jobs:
       if: github.event_name == 'release' && github.event.action == 'published'
 
     - name: Setup Environment
-      run: | 
+      run: |
         mkdir ${{ env.PROJECT_RELEASE_PATH }}
         dir
       shell: cmd


### PR DESCRIPTION
It will fail if `RAYLIB_SRC_PATH` is set in CI. I cannot find `RAYLIB_PROJECT_RELEASE_PATH` in Raylib's Makefile, so I believe this is a typo.

Correct `RAYLIB_PROJECT_RELEASE_PATH` -> `RAYLIB_RELEASE_PATH`.

Also remove trailing spaces.